### PR TITLE
Temporary workaround for media that are not exported as blob but by url

### DIFF
--- a/mod_import_anymeta.erl
+++ b/mod_import_anymeta.erl
@@ -464,7 +464,8 @@ import_thing(Host, AnymetaId, Thing, KeepId, Stats, Context) ->
                                         undefined ->
                                             Stats3;
                                         _ ->
-                                            % TO DO save the file from url ? m_media:replace_url(Url, RscId, [], Context),
+                                            Url = proplists:get_value(<<"uri">>, File),
+                                            m_media:replace_url(Url, RscId, [], Context),
                                             Stats3
                                     end;
                                 {struct, Fileblob} -> 


### PR DESCRIPTION
In order to get a whole export/import run working without crashing, I temporarily skipped media from url. At this moment I don't have enough erlang/zotonic skills to get m_media:replace_url working.
This would be a moment to have an actual unit test for further development on this issue.
So help with all this is much appreciated! 
