### PR TITLE
Newly created predicate is not found

### DIFF
--- a/mod_import_anymeta.erl
+++ b/mod_import_anymeta.erl
@@ -900,7 +900,8 @@ write_rsc(AnymetaId, Fields, KeepId, Stats, Context) ->
                         {name, z_convert:to_binary(Predicate)},
                         {category, predicate},
                         {title, z_convert:to_binary(Predicate)}
-                    ], Context)
+                    ], Context),
+                z_depcache:flush(Context)
         end.
 
 


### PR DESCRIPTION
Right after the creation of a new predicate the edge can't be made using this predicate and breaks the import. Flushing the cache fixes this problem.
