### PR TITLE
Cleanup any existing duplicate name before inserting a new predicate

### DIFF
--- a/mod_import_anymeta.erl
+++ b/mod_import_anymeta.erl
@@ -414,6 +414,7 @@ import_thing(Host, AnymetaId, Thing, KeepId, Stats, Context) ->
         false ->
             {struct, Texts} = proplists:get_value(<<"lang">>, Thing),
             RscUri = proplists:get_value(<<"resource_uri">>, Thing),
+            Authoritative = proplists:get_value(<<"authoritative">>, Thing),
             Texts1 = [ map_texts(map_language(Lang), T) || {Lang, {struct, T}} <- Texts ],
             Texts2 = group_by_lang(Texts1),
             Websites = proplists:get_value(website, Texts2),
@@ -426,7 +427,8 @@ import_thing(Host, AnymetaId, Thing, KeepId, Stats, Context) ->
                         {anymeta_id, AnymetaId},
                         {anymeta_rsc_uri, RscUri},
                         {anymeta_host, Host},
-                        {language, Langs}
+                        {language, Langs},
+                        {is_authoritative, Authoritative}
                         |OtherFields
                      ]
                      ++ fetch_address(Thing)

--- a/mod_import_anymeta.erl
+++ b/mod_import_anymeta.erl
@@ -905,12 +905,6 @@ write_rsc(AnymetaId, Fields, KeepId, Stats, Context) ->
             {ok, _Id} ->
                 ok;
             {error, _} ->
-                case m_rsc:name_to_id(Predicate, Context) of
-                    {ok, Id} ->
-                        m_rsc_update:update(Id, [{name, undefined}], Context);
-                    {error, _} ->
-                        none
-                end,
                 m_rsc:insert([
                         {name, z_convert:to_binary(Predicate)},
                         {category, predicate},

--- a/mod_import_anymeta.erl
+++ b/mod_import_anymeta.erl
@@ -903,6 +903,12 @@ write_rsc(AnymetaId, Fields, KeepId, Stats, Context) ->
             {ok, _Id} ->
                 ok;
             {error, _} ->
+                case m_rsc:name_to_id(Predicate, Context) of
+                    {ok, Id} ->
+                        m_rsc_update:update(Id, [{name, undefined}], Context);
+                    {error, _} ->
+                        none
+                end,
                 m_rsc:insert([
                         {name, z_convert:to_binary(Predicate)},
                         {category, predicate},


### PR DESCRIPTION
Assuming a predicate name is more important then a previously imported resource with the same name.